### PR TITLE
Feature/custom ssh port (updated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ return [
              * The full path to the directory where the logs are located
              */
             'logDirectory' => '',
+            
+            /*
+             * The port of remote ssh
+             */
+            'port' => '22'
         ],
     ],
 ];

--- a/src/TailCommand.php
+++ b/src/TailCommand.php
@@ -74,12 +74,13 @@ class TailCommand extends Command
     protected function tailRemoteLogFile($connection)
     {
         $connectionParameters = config('tail.connections.'.$connection);
-        $PORT = @$connectionParameters['port'] ?: 22;
+        
+        $port = $connectionParameters['port'];
         $this->guardAgainstInvalidConnectionParameters($connectionParameters);
 
-        $tailCommand = 'ssh '.($connectionParameters['user'] == '' ? '' : $connectionParameters['user'].'@').$connectionParameters['host']." -p " . $PORT . " -T 'cd ".$connectionParameters['logDirectory'].';tail -n '.$this->option('lines')." -f $(ls -t | head -n 1)'";
+        $tailCommand = 'ssh '.($connectionParameters['user'] == '' ? '' : $connectionParameters['user'].'@').$connectionParameters['host']." -p " . $port . " -T 'cd ".$connectionParameters['logDirectory'].';tail -n '.$this->option('lines')." -f $(ls -t | head -n 1)'";
 
-        $this->info('start tailing latest remote log on host '.$connectionParameters['host'].' (port '.$PORT.') in directory '.$connectionParameters['logDirectory']);
+        $this->info('start tailing latest remote log on host '.$connectionParameters['host'].' (port '.$port.') in directory '.$connectionParameters['logDirectory']);
 
         $this->executeCommand($tailCommand);
     }

--- a/src/TailCommand.php
+++ b/src/TailCommand.php
@@ -74,12 +74,12 @@ class TailCommand extends Command
     protected function tailRemoteLogFile($connection)
     {
         $connectionParameters = config('tail.connections.'.$connection);
-
+        $PORT = @$connectionParameters['port'] ?: 22;
         $this->guardAgainstInvalidConnectionParameters($connectionParameters);
 
-        $tailCommand = 'ssh '.($connectionParameters['user'] == '' ? '' : $connectionParameters['user'].'@').$connectionParameters['host']." -T 'cd ".$connectionParameters['logDirectory'].';tail -n '.$this->option('lines')." -f $(ls -t | head -n 1)'";
+        $tailCommand = 'ssh '.($connectionParameters['user'] == '' ? '' : $connectionParameters['user'].'@').$connectionParameters['host']." -p " . $PORT . " -T 'cd ".$connectionParameters['logDirectory'].';tail -n '.$this->option('lines')." -f $(ls -t | head -n 1)'";
 
-        $this->info('start tailing latest remote log on host '.$connectionParameters['host'].' in directory '.$connectionParameters['logDirectory']);
+        $this->info('start tailing latest remote log on host '.$connectionParameters['host'].' (port '.$PORT.') in directory '.$connectionParameters['logDirectory']);
 
         $this->executeCommand($tailCommand);
     }

--- a/src/TailCommand.php
+++ b/src/TailCommand.php
@@ -75,7 +75,13 @@ class TailCommand extends Command
     {
         $connectionParameters = config('tail.connections.'.$connection);
         
-        $port = $connectionParameters['port'];
+        // set default port to 22 or use the port
+        // from config file if `port` is defined.
+        $port = 22;
+        if (!empty($connectionParameters['port'])) {
+        	$port = $connectionParameters['port'];
+        }
+
         $this->guardAgainstInvalidConnectionParameters($connectionParameters);
 
         $tailCommand = 'ssh '.($connectionParameters['user'] == '' ? '' : $connectionParameters['user'].'@').$connectionParameters['host']." -p " . $port . " -T 'cd ".$connectionParameters['logDirectory'].';tail -n '.$this->option('lines')." -f $(ls -t | head -n 1)'";

--- a/src/config/tail.php
+++ b/src/config/tail.php
@@ -23,6 +23,11 @@ return [
              * The full path to the directory where the logs are located
              */
             'logDirectory' => '',
+
+            /*
+             * The port of remote ssh
+             */
+            'port' => '22'
         ],
     ],
 ];


### PR DESCRIPTION
- Renamed `$PORT` $port`
- removed `@$connectionParameters['port'] ?: 22;` because the port is already defined in config file
