### PR TITLE
Updates required packages to remove 5.5-dev references.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     ],
     "require": {
         "php" : "^7.0",
-        "illuminate/support": "5.5.x-dev",
-        "illuminate/console": "5.5.x-dev",
+        "illuminate/support": "^5.5",
+        "illuminate/console": "^5.5",
         "symfony/process": "^3.3"
     },
     "autoload": {


### PR DESCRIPTION
`Composer.json` file still had references to `5.5-dev` that is preventing installation.

Updated to:
```json
    "require": {
        "php" : "^7.0",
        "illuminate/support": "^5.5",
        "illuminate/console": "^5.5",
        "symfony/process": "^3.3"
    },
```