### PR TITLE
Add --clear option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-tail` will be documented in this file
 
+### 3.1.0 - 2018-04-12
+
+- Add `--clear` option
+
 ### 3.0.1 - 2018-02-07
 
 - fix deps

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ You can start the output with displaying the last lines in the log by using the 
 php artisan tail --lines=50
 ```
 
+It's also possible to fully clear the output buffer after each log item.
+This can be useful if you're only interested in the last log entry when debugging.
+
+```bash
+php artisan tail --clear
+```
+
 ### Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/TailCommand.php
+++ b/src/TailCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Process\Process;
 
 class TailCommand extends Command
 {
-    protected $signature = 'tail {--lines=0}';
+    protected $signature = 'tail {--lines=0} {--clear}';
 
     protected $description = 'Tail the latest logfile';
 
@@ -27,9 +27,13 @@ class TailCommand extends Command
 
         $tailCommand = "tail -f -n {$lines} ".escapeshellarg($path);
 
+        $this->optionallyClear();
+
         (new Process($tailCommand))
             ->setTimeout(null)
             ->run(function ($type, $line) {
+                $this->optionallyClear();
+
                 $this->output->write($line);
             });
     }
@@ -45,6 +49,15 @@ class TailCommand extends Command
         return $logFile
             ? $logFile->getPathname()
             : false;
+    }
+
+    protected function optionallyClear()
+    {
+        if (!$this->option('clear')) {
+            return;
+        }
+
+        $this->output->write(sprintf("\033\143\e[3J"));
     }
 
     protected function executeCommand($command)

--- a/src/TailCommand.php
+++ b/src/TailCommand.php
@@ -27,12 +27,12 @@ class TailCommand extends Command
 
         $tailCommand = "tail -f -n {$lines} ".escapeshellarg($path);
 
-        $this->optionallyClear();
+        $this->handleClearOption();
 
         (new Process($tailCommand))
             ->setTimeout(null)
             ->run(function ($type, $line) {
-                $this->optionallyClear();
+                $this->handleClearOption();
 
                 $this->output->write($line);
             });
@@ -51,7 +51,7 @@ class TailCommand extends Command
             : false;
     }
 
-    protected function optionallyClear()
+    protected function handleClearOption()
     {
         if (! $this->option('clear')) {
             return;


### PR DESCRIPTION
This PR adds the `--clear` option. When this option is provided, the output buffer will be completely cleared after logging an item. It allows for much easier to read stack traces and long log messages.