### PR TITLE
Remove the provides() method

### DIFF
--- a/src/TailServiceProvider.php
+++ b/src/TailServiceProvider.php
@@ -14,9 +14,4 @@ class TailServiceProvider extends ServiceProvider
             ]);
         }
     }
-
-    public function provides()
-    {
-        return ['command.tail'];
-    }
 }


### PR DESCRIPTION
I'm pretty sure you don't need this method. The service provider isn't setting anything in the IoC container, let alone anything with this name.