### PR TITLE
Fix filter argument order

### DIFF
--- a/src/TailCommand.php
+++ b/src/TailCommand.php
@@ -30,7 +30,7 @@ class TailCommand extends Command
 
         $filters = $this->getFilters();
 
-        $tailCommand = "tail -f -n {$lines} {$filters} ".escapeshellarg($path);
+        $tailCommand = "tail -n {$lines} -f ".escapeshellarg($path)." {$filters}";
 
         $this->handleClearOption();
 


### PR DESCRIPTION
Hopefully this one does the trick!

As mentioned in the comments of the previous PR, there seems to be a slight limitation when mixing the `--lines` & `--hide-stack-traces` options. What seems to happen is `tail -n [num]` selects the log file lines _before_ the filter is applied, so when using `tail -n 50`, for example, fewer lines might be output because the stack traces will be filtered from those 50 lines.

Perhaps someone else can find a way around this, but I don't know if it's possible natively using `tail`'s own options.