### PR TITLE
fix --grep option

### DIFF
--- a/src/TailCommand.php
+++ b/src/TailCommand.php
@@ -12,7 +12,7 @@ class TailCommand extends Command
     protected $signature = 'tail {environment?}
                             {--lines=0 : Output the last number of lines}
                             {--clear : Clear the terminal screen}
-                            {--grep : Grep specified string}
+                            {--grep= : Grep specified string}
                             {--debug : "Display the underlying tail command}';
 
     protected $description = 'Tail the latest logfile';


### PR DESCRIPTION
Without the equal sign I get an error `The "--grep" option does not accept a value.` But the tests still pass which is incorrect.

From Laravel Docs: https://laravel.com/docs/7.x/artisan#options-with-values

`Next, let's take a look at an option that expects a value. If the user must specify a value for an option, suffix the option name with a = sign:`