### PR TITLE
Add file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ You can start the output with displaying the last lines in the log by using the 
 php artisan tail --lines=50
 ```
 
+By default, the most-recently modified file in the directory will be used.
+You can specify the file that you would like to tail by using the `file` option.
+
+```bash
+php artisan tail --file="other-file.log"
+```
+
 It's also possible to fully clear the output buffer after each log item.
 This can be useful if you're only interested in the last log entry when debugging.
 
@@ -96,7 +103,7 @@ php artisan tail --grep="only display lines that contain this string"
 
 ### Tailing remote logs
 
-To tail remote logs, you must first specify values for `host`, `user` and `log_directory` keys of an environment in the `tail` config file.
+To tail remote logs, you must first specify values for `host`, `user`, `log_directory`, and `file` keys of an environment in the `tail` config file.
 
 After that you can tail that logs of an environment like this
 
@@ -104,7 +111,7 @@ After that you can tail that logs of an environment like this
 php artisan tail production
 ```
 
-You can also use the `--clear` and `--lines` options described above.
+You can also use the `--clear`, `--file`, and `--lines` options described above.
 
 ### Changelog
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ return [
          * The path to the directory that contains your logs.
          */
         'log_directory' => env('TAIL_LOG_DIRECTORY_PRODUCTION', ''),
+
+        /*
+         * The filename of the log file that you want to tail.
+         * Leave null to let the package automatically select the file.
+         */
+        'file' => env('TAIL_LOG_FILE_PRODUCTION', null),
         
     ],
 ];

--- a/config/tail.php
+++ b/config/tail.php
@@ -18,5 +18,11 @@ return [
          */
         'log_directory' => env('TAIL_LOG_DIRECTORY_PRODUCTION', ''),
 
+        /*
+         * The filename of the log file that you want to tail.
+         * Leave null to let the package automatically select the file to tail.
+         */
+        'file' => env('TAIL_LOG_FILE_PRODUCTION', null),
+
     ],
 ];

--- a/tests/TailCommandTest.php
+++ b/tests/TailCommandTest.php
@@ -25,6 +25,17 @@ class TailCommandTest extends TestCase
     }
 
     /** @test */
+    public function the_tail_command_with_file_is_correct()
+    {
+        $this
+            ->artisan('tail', [
+                '--debug' => true,
+                '--file' => 'file.log',
+            ])
+            ->expectsOutput('tail -f -n 0 "file.log"');
+    }
+
+    /** @test */
     public function the_command_when_grepping_is_correct()
     {
         $this


### PR DESCRIPTION
I've had a number of instances where I needed to tail a specific log file (for example, I log third-party API calls to a different file for each service). This PR adds a `--file` option that lets you specify the file that you want to `tail`, rather than only being able to see the last-modified file in the directory.

The relevant test was added, and I updated the readme to describe the use case and usage. I also added a config value to allow the file to specified per-environment (optional, of course).

Please let me know any feedback or requested changes. Thank you!