### PR TITLE
Prefix all shell commands with backslashes to ignore aliases

### DIFF
--- a/src/TailCommand.php
+++ b/src/TailCommand.php
@@ -49,13 +49,13 @@ class TailCommand extends Command
         $logDirectory = storage_path('logs');
 
         Process::fromShellCommandline($this->getTailCommand(), $logDirectory)
-               ->setTty(true)
-               ->setTimeout(null)
-               ->run(function ($type, $line) {
-                   $this->handleClearOption();
+            ->setTty(true)
+            ->setTimeout(null)
+            ->run(function ($type, $line) {
+                $this->handleClearOption();
 
-                   $this->output->write($line);
-               });
+                $this->output->write($line);
+            });
     }
 
     protected function tailRemotely(string $environment): void
@@ -63,16 +63,16 @@ class TailCommand extends Command
         $environmentConfig = $this->getEnvironmentConfiguration($environment);
 
         Ssh::create($environmentConfig['user'], $environmentConfig['host'])
-           ->configureProcess(fn (Process $process) => $process->setTty(true))
-           ->onOutput(function ($type, $line) {
-               $this->handleClearOption();
+            ->configureProcess(fn (Process $process) => $process->setTty(true))
+            ->onOutput(function ($type, $line) {
+                $this->handleClearOption();
 
-               $this->output->write($line);
-           })
-           ->execute([
-               "cd {$environmentConfig['log_directory']}",
-               $this->getTailCommand(),
-           ]);
+                $this->output->write($line);
+            })
+            ->execute([
+                "cd {$environmentConfig['log_directory']}",
+                $this->getTailCommand(),
+            ]);
     }
 
     protected function getEnvironmentConfiguration(string $environment): array
@@ -94,8 +94,8 @@ class TailCommand extends Command
             : $this->getEnvironmentConfiguration($environment);
 
         return $this->option('file')
-               ?? $environmentConfig['file']
-               ?? "`\\ls -t | \\head -1`";
+            ?? $environmentConfig['file']
+            ?? "`\\ls -t | \\head -1`";
     }
 
     public function getTailCommand(): string

--- a/src/TailCommand.php
+++ b/src/TailCommand.php
@@ -49,13 +49,13 @@ class TailCommand extends Command
         $logDirectory = storage_path('logs');
 
         Process::fromShellCommandline($this->getTailCommand(), $logDirectory)
-            ->setTty(true)
-            ->setTimeout(null)
-            ->run(function ($type, $line) {
-                $this->handleClearOption();
+               ->setTty(true)
+               ->setTimeout(null)
+               ->run(function ($type, $line) {
+                   $this->handleClearOption();
 
-                $this->output->write($line);
-            });
+                   $this->output->write($line);
+               });
     }
 
     protected function tailRemotely(string $environment): void
@@ -63,16 +63,16 @@ class TailCommand extends Command
         $environmentConfig = $this->getEnvironmentConfiguration($environment);
 
         Ssh::create($environmentConfig['user'], $environmentConfig['host'])
-            ->configureProcess(fn (Process $process) => $process->setTty(true))
-            ->onOutput(function ($type, $line) {
-                $this->handleClearOption();
+           ->configureProcess(fn (Process $process) => $process->setTty(true))
+           ->onOutput(function ($type, $line) {
+               $this->handleClearOption();
 
-                $this->output->write($line);
-            })
-            ->execute([
-                "cd {$environmentConfig['log_directory']}",
-                $this->getTailCommand(),
-            ]);
+               $this->output->write($line);
+           })
+           ->execute([
+               "cd {$environmentConfig['log_directory']}",
+               $this->getTailCommand(),
+           ]);
     }
 
     protected function getEnvironmentConfiguration(string $environment): array
@@ -94,17 +94,17 @@ class TailCommand extends Command
             : $this->getEnvironmentConfiguration($environment);
 
         return $this->option('file')
-            ?? $environmentConfig['file']
-            ?? "`ls -t | head -1`";
+               ?? $environmentConfig['file']
+               ?? "`\\ls -t | \\head -1`";
     }
 
     public function getTailCommand(): string
     {
         $grep = $this->option('grep')
-            ? ' | grep "'.$this->option('grep').'"'
+            ? ' | \\grep "'.$this->option('grep').'"'
             : '';
         $file = $this->getTailFile();
 
-        return 'tail -f -n '.$this->option('lines').' "'.$file.'"'.$grep;
+        return '\\tail -f -n '.$this->option('lines').' "'.$file.'"'.$grep;
     }
 }

--- a/tests/TailCommandTest.php
+++ b/tests/TailCommandTest.php
@@ -21,7 +21,7 @@ class TailCommandTest extends TestCase
             ->artisan('tail', [
                 '--debug' => true,
             ])
-            ->expectsOutput('tail -f -n 0 "`ls -t | head -1`"');
+            ->expectsOutput('\\tail -f -n 0 "`\\ls -t | \\head -1`"');
     }
 
     /** @test */
@@ -32,7 +32,7 @@ class TailCommandTest extends TestCase
                 '--debug' => true,
                 '--file' => 'file.log',
             ])
-            ->expectsOutput('tail -f -n 0 "file.log"');
+            ->expectsOutput('\\tail -f -n 0 "file.log"');
     }
 
     /** @test */
@@ -43,6 +43,6 @@ class TailCommandTest extends TestCase
                 '--debug' => true,
                 '--grep' => 'test',
             ])
-            ->expectsOutput('tail -f -n 0 "`ls -t | head -1`" | grep "test"');
+            ->expectsOutput('\\tail -f -n 0 "`\\ls -t | \\head -1`" | \\grep "test"');
     }
 }


### PR DESCRIPTION
I recently began using [exa](https://github.com/ogham/exa) to replace `ls`. To make the switch easier, I aliased `ls`:

```
$ which ls
ls: aliased to exa --icons --classify --header --git
```

As a result, the command this package uses to get the latest log file (`ls -t`) throws an error instead of listing the sorted files:

```
$ ls -t
exa: Flag -t needs a value (choices: modified, changed, accessed, created)
To sort newest files last, try "--sort newest", or just "-snew"
```

The package uses the `ls`, `head`, `tail`, and `grep` shell commands, and they all could potentially be aliased/overwritten on the user's system. This could break the package, and there is no way of knowing because the output is suppressed:

![image](https://user-images.githubusercontent.com/748444/124039525-53ee3380-d9c0-11eb-9610-c842737262e0.png)

This PR simply adds backslashes to the beginning of each shell command so that aliases are ignored and the native shell commands are used instead.

I _can_ manually specify the escaped command with `--file` to get it to work, but it's janky and you'll only know to do it this way if you know why it's throwing the error in the first place:

```zsh
php artisan tail --file="\`\\ls -t | \\head -1\`"
```

Thanks!