### PR TITLE
Extended config to set log file on default 'local' environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,29 +43,45 @@ This is the contents of the file that will be published at `config/tail.php`:
 
 ```php
 return [
-    'production' => [
-        
-        /*
-         * The host that contains your logs.
-         */
-        'host' => env('TAIL_HOST_PRODUCTION', ''),
+    /*
+     * This environment will be used if none is specified
+     * when executing the `tail` command.
+     */
+    'default_environment' => env('TAIL_DEFAULT_ENVIRONMENT', 'local'),
 
-        /*
-         * The user to be used to SSH to the server.
-         */
-        'user' => env('TAIL_USER_PRODUCTION', ''),
+    'environments' => [
 
-        /*
-         * The path to the directory that contains your logs.
-         */
-        'log_directory' => env('TAIL_LOG_DIRECTORY_PRODUCTION', ''),
+        'local' => [
+            /*
+             * The filename of the log file that you want to tail.
+             * Leave null to let the package automatically select the file to tail.
+             */
+            'file' => env('TAIL_LOG_FILE'),
+        ],
 
-        /*
-         * The filename of the log file that you want to tail.
-         * Leave null to let the package automatically select the file.
-         */
-        'file' => env('TAIL_LOG_FILE_PRODUCTION', null),
-        
+        'production' => [
+            /*
+             * The host that contains your logs.
+             */
+            'host' => env('TAIL_HOST_PRODUCTION', ''),
+
+            /*
+             * The user to be used to SSH to the server.
+             */
+            'user' => env('TAIL_USER_PRODUCTION', ''),
+
+            /*
+             * The path to the directory that contains your logs.
+             */
+            'log_directory' => env('TAIL_LOG_DIRECTORY_PRODUCTION', ''),
+
+            /*
+             * The filename of the log file that you want to tail.
+             * Leave null to let the package automatically select the file to tail.
+             */
+            'file' => env('TAIL_LOG_FILE_PRODUCTION'),
+        ],
+
     ],
 ];
 ```
@@ -90,6 +106,8 @@ You can specify the file that you would like to tail by using the `file` option.
 ```bash
 php artisan tail --file="other-file.log"
 ```
+
+Instead of using the `file` option, you could also override the automatic file detection by putting `TAIL_LOG_FILE=laravel.log` into your `.env`.
 
 It's also possible to fully clear the output buffer after each log item.
 This can be useful if you're only interested in the last log entry when debugging.

--- a/config/tail.php
+++ b/config/tail.php
@@ -1,28 +1,44 @@
 <?php
 
 return [
-    'production' => [
+    /*
+     * This environment will be used if none is specified
+     * when executing the `tail` command.
+     */
+    'default_environment' => env('TAIL_DEFAULT_ENVIRONMENT', 'local'),
 
-        /*
-         * The host that contains your logs.
-         */
-        'host' => env('TAIL_HOST_PRODUCTION', ''),
+    'environments' => [
 
-        /*
-         * The user to be used to SSH to the server.
-         */
-        'user' => env('TAIL_USER_PRODUCTION', ''),
+        'local' => [
+            /*
+             * The filename of the log file that you want to tail.
+             * Leave null to let the package automatically select the file to tail.
+             */
+            'file' => env('TAIL_LOG_FILE'),
+        ],
 
-        /*
-         * The path to the directory that contains your logs.
-         */
-        'log_directory' => env('TAIL_LOG_DIRECTORY_PRODUCTION', ''),
+        'production' => [
+            /*
+             * The host that contains your logs.
+             */
+            'host' => env('TAIL_HOST_PRODUCTION', ''),
 
-        /*
-         * The filename of the log file that you want to tail.
-         * Leave null to let the package automatically select the file to tail.
-         */
-        'file' => env('TAIL_LOG_FILE_PRODUCTION', null),
+            /*
+             * The user to be used to SSH to the server.
+             */
+            'user' => env('TAIL_USER_PRODUCTION', ''),
+
+            /*
+             * The path to the directory that contains your logs.
+             */
+            'log_directory' => env('TAIL_LOG_DIRECTORY_PRODUCTION', ''),
+
+            /*
+             * The filename of the log file that you want to tail.
+             * Leave null to let the package automatically select the file to tail.
+             */
+            'file' => env('TAIL_LOG_FILE_PRODUCTION'),
+        ],
 
     ],
 ];


### PR DESCRIPTION
Up to now it was impossible to configure a default log file for the default environment, when no explicit environment was passed with `--environment` argument.

The problem arises e.g. if you have some deprecation warnings in your app which makes `php-deprecation-warnings.log` mostly have a newer timestamp than the application log `laravel.log`, which you usually want to follow. This can be frustrating for a newbie who just wants to install `spatie/laravel-tail` without any extra configuration and by simply using `php artisan tail` command, as there's no output of which log file is followed.

This PR extends the `config/tail.php` and the structure in it, so it's a breaking change. But if a future user ever removes the default `local` environment configuration in it, that's handled and no defaults were changed. If you merge this, please put some warning in your CHANGELOG to make people know they need to re-publish/update their config file.

With this patch applied, you can just set the default local log file with `TAIL_LOG_FILE=laravel.log` in your `.env`.